### PR TITLE
Deployable Balance & Nodes

### DIFF
--- a/code/_core/datum/ai/simple/turret.dm
+++ b/code/_core/datum/ai/simple/turret.dm
@@ -68,6 +68,7 @@
 
 /ai/turret/deployable
 	var/mob/living/simple/turret/deployable/owner_as_turret
+	use_cone_vision = FALSE//360 degree scan.
 
 /ai/turret/deployable/New(var/mob/living/desired_owner)
 	. = ..()
@@ -87,3 +88,10 @@
 	B.charge_current = max(B.charge_current - AI_TICK,0)
 
 	return ..()
+
+/ai/turret/special
+	radius_find_enemy = VIEW_RANGE + ZOOM_RANGE
+	radius_find_enemy_noise = VIEW_RANGE + ZOOM_RANGE
+	true_sight = TRUE
+	use_cone_vision = FALSE//360 degree scan.
+	assistance = 1

--- a/code/_core/datum/gamemode/horde_types.dm
+++ b/code/_core/datum/gamemode/horde_types.dm
@@ -114,7 +114,7 @@
 
 /gamemode/horde/halo
 	name = "URF vs UNSC"
-	desc = "Fight off an group of insurrectionists or marines, while compliting objectives."
+	desc = "Fight off a group of insurrectionists in this wave based gamemode!"
 	enemy_types_to_spawn = list()
 	hidden = TRUE //temp
 	unsc_points = 100

--- a/code/_core/mob/living/simple/turret.dm
+++ b/code/_core/mob/living/simple/turret.dm
@@ -82,6 +82,7 @@
 	iff_tag = "NanoTrasen"
 	loyalty_tag = "NanoTrasen"
 	stored_weapon = /obj/item/weapon/ranged/energy/unsc_sentry
+	ai = /ai/turret/special
 
 /mob/living/simple/turret/unsc/post_death()
 	icon_state = "dead"

--- a/maps/horde/standard.dmm
+++ b/maps/horde/standard.dmm
@@ -663,7 +663,6 @@
 "mM" = (/obj/decal/hazard{dir = 10},/obj/structure/interactive/lighting/fixture/floor/stronger,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "mN" = (/turf/simulated/wall/plastic/office/darker/indestructable,/area/halo/interior)
 "mO" = (/turf/simulated/wall/plastic/office/darker/indestructable,/area/halo/interior/geminus/mining)
-"mP" = (/obj/effect/fog_of_war,/turf/simulated/wall/plastic/office/darker,/area/halo/interior)
 "mQ" = (/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "mR" = (/obj/structure/interactive/lighting/fixture/bulb,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "mS" = (/turf/simulated/wall/plastic/office/darker,/area/halo/interior)
@@ -698,7 +697,7 @@
 "nv" = (/obj/decal/sidewalk/corner{dir = 4; icon_state = "cobble_corner2"},/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "nw" = (/obj/structure/interactive/lighting/fixture/floor/stronger,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "nx" = (/mob/living/advanced/npc/halo/marine{dir = 4; icon_state = "directional"},/turf/simulated/floor/grass,/area/halo/exterior/jungle)
-"ny" = (/obj/decal/sidewalk/corner{dir = 8; icon_state = "cobble_corner2"},/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
+"ny" = (/obj/decal/sidewalk/side,/obj/marker/map_node,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "nz" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 8},/turf/simulated/floor/plating,/area/halo/interior)
 "nA" = (/obj/structure/smooth/table/reinforced/dark,/obj/structure/interactive/computer/console/laptop{dir = 1; icon_state = "laptop"},/turf/simulated/floor/tile/cargo,/area/halo/interior/geminus/mining)
 "nB" = (/obj/structure/interactive/door/airlock/glass,/turf/simulated/floor/tile/cargo,/area/halo/interior/geminus/mining)
@@ -738,7 +737,6 @@
 "oj" = (/obj/decal/hazard{dir = 4},/obj/structure/interactive/lighting/fixture/floor/stronger,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "ok" = (/obj/structure/smooth/table/wood,/obj/item/container/food/dynamic/chicken/cooked,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "ol" = (/obj/structure/smooth/table/wood,/obj/item/container/food/dynamic/meat/cooked_steak,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
-"om" = (/obj/effect/fog_of_war,/turf/simulated/wall/brick/red/dark,/area/halo/interior)
 "on" = (/turf/simulated/wall/brick/red/dark,/area/halo/interior)
 "oo" = (/obj/structure/interactive/door/airlock,/turf/simulated/floor/wood/rich,/area/halo/interior)
 "op" = (/obj/structure/smooth/table/rack/grey,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/car_storage)
@@ -819,7 +817,6 @@
 "pM" = (/obj/structure/interactive/misc/mirror{pixel_x = 32},/turf/simulated/floor/wood/rich,/area/halo/interior/geminus/morgue)
 "pN" = (/obj/structure/interactive/telecomms,/turf/simulated/floor/tile/dark/ish,/area/halo/interior)
 "pO" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/turf/simulated/floor/tile/dark/ish,/area/halo/interior)
-"pP" = (/obj/effect/fog_of_war,/turf/simulated/wall/plastic/office,/area/halo/interior)
 "pQ" = (/obj/structure/smooth/table/reinforced/dark,/obj/structure/interactive/fax_machine,/turf/simulated/floor/wood/rich,/area/halo/interior/geminus/car_storage)
 "pR" = (/mob/living/advanced/npc/halo/marine,/turf/simulated/floor/plating,/area/halo/interior/geminus/car_storage)
 "pS" = (/mob/living/advanced/npc/halo/kigyar/ranged{dir = 4; icon_state = "halo_kigyar1"},/turf/simulated/floor/tile/medical,/area/halo/interior/geminus/morgue)
@@ -846,7 +843,7 @@
 "qn" = (/obj/decal/tile/medbay,/obj/structure/interactive/vending/medical/chemistry,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
 "qo" = (/obj/decal/tile/medbay,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
 "qp" = (/obj/decal/tile/medbay,/obj/decal/tile/medbay{dir = 4; icon_state = "tile"},/obj/structure/interactive/lighting/fixture/tube/station{dir = 1},/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
-"qq" = (/obj/structure/interactive/chair/wood{dir = 1; icon_state = "wooden_chair"},/turf/simulated/floor/wood/rich,/area/halo/interior/geminus/morgue)
+"qq" = (/obj/marker/map_node,/turf/simulated/floor/plating,/area/halo/interior)
 "qr" = (/obj/structure/smooth/table/rack/grey,/turf/simulated/floor/wood/rich,/area/halo/interior/geminus/morgue)
 "qs" = (/obj/decal/hazard{dir = 5},/obj/structure/interactive/lighting/fixture/floor/stronger,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "qt" = (/obj/decal/hazard,/obj/structure/interactive/lighting/fixture/floor/stronger,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
@@ -875,14 +872,12 @@
 "qQ" = (/obj/structure/smooth/table/rack/grey,/obj/structure/interactive/lighting/fixture/tube/station,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
 "qR" = (/obj/structure/interactive/crate/open,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
 "qS" = (/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
-"qT" = (/obj/effect/fog_of_war,/turf/simulated/floor/plating,/area/halo/interior)
-"qU" = (/obj/structure/scenery/rocks,/obj/effect/fog_of_war,/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
 "qV" = (/obj/structure/interactive/bed/padded,/obj/structure/interactive/lighting/fixture/tube/station{dir = 1},/turf/simulated/floor/carpet,/area/halo/interior)
 "qW" = (/mob/living/advanced/npc/halo/unggoy,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "qX" = (/obj/decal/tile/medbay{dir = 8; icon_state = "tile"},/obj/decal/tile/medbay{dir = 1; icon_state = "tile"},/obj/structure/interactive/door/airlock/glass,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
 "qY" = (/obj/decal/tile/medbay{dir = 9; icon_state = "tile"},/mob/living/advanced/npc/halo/marine{dir = 8; icon_state = "directional"},/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
 "qZ" = (/obj/structure/interactive/door/airlock/station/dark,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
-"ra" = (/mob/living/advanced/npc/halo/kigyar/ranged,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
+"ra" = (/obj/marker/map_node,/mob/living/advanced/npc/halo/marine,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "rb" = (/obj/item/storage/heavy/trash_pile,/turf/simulated/floor/plating,/area/halo/interior)
 "rc" = (/obj/structure/interactive/door/airlock,/turf/simulated/floor/carpet,/area/halo/interior)
 "rd" = (/obj/structure/interactive/lighting/streetlamp/strong,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
@@ -929,7 +924,7 @@
 "rS" = (/obj/structure/interactive/chair{dir = 1},/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/turf/simulated/floor/wood/boat/starting,/area/halo/interior)
 "rT" = (/mob/living/advanced/npc/halo/unggoy{dir = 8; icon_state = "halo_unggoy"},/turf/simulated/floor/colored/ash/dark,/area/halo/exterior/jungle)
 "rU" = (/obj/decal/tile/medbay,/obj/decal/tile/medbay{dir = 8; icon_state = "tile"},/obj/structure/interactive/chair/stool,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
-"rV" = (/obj/decal/tile/medbay,/obj/decal/tile/medbay{dir = 4; icon_state = "tile"},/obj/structure/interactive/lighting/fixture/tube/station{dir = 8},/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
+"rV" = (/obj/marker/map_node,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "rW" = (/obj/structure/smooth/table/rack/grey,/obj/structure/interactive/crate/medical,/obj/structure/interactive/lighting/fixture/tube/station{dir = 1},/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
 "rX" = (/obj/structure/interactive/crate,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
 "rY" = (/obj/structure/smooth/table/rack/grey,/obj/structure/interactive/lighting/fixture/tube/station{dir = 1},/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
@@ -948,7 +943,7 @@
 "sl" = (/obj/structure/interactive/barricade{dir = 4; icon_state = "metal"},/obj/structure/interactive/barricade{dir = 1; icon_state = "metal"},/turf/simulated/floor/colored/ash/dark,/area/halo/exterior/jungle)
 "sm" = (/obj/decal/sidewalk/side{dir = 1; icon_state = "cobble_side2"},/obj/decal/sidewalk/side{dir = 8; icon_state = "cobble_side2"},/obj/decal/sidewalk/side,/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
 "sn" = (/obj/decal/sidewalk/side{dir = 1; icon_state = "cobble_side2"},/obj/decal/sidewalk/side,/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
-"so" = (/obj/decal/sidewalk/side,/mob/living/advanced/npc/halo/marine{dir = 4; icon_state = "directional"},/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
+"so" = (/obj/decal/sidewalk/corner{dir = 8; icon_state = "cobble_corner2"},/obj/marker/map_node,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "sp" = (/obj/decal/sidewalk/side{dir = 1; icon_state = "cobble_side2"},/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
 "sq" = (/turf/simulated/wall/plastic/office/darker,/area/halo/interior/comm_unsc)
 "sr" = (/obj/structure/interactive/construction/grille,/obj/structure/smooth/window/reinforced,/obj/structure/interactive/misc/curtain_open,/turf/simulated/floor/plating,/area/halo/interior/comm_unsc)
@@ -1037,7 +1032,7 @@
 "tW" = (/mob/living/advanced/npc/halo/marine{dir = 8; icon_state = "directional"},/turf/simulated/floor/plating,/area/halo/interior)
 "tX" = (/mob/living/advanced/npc/halo/kigyar{dir = 1; icon_state = "halo_kigyar1"},/turf/simulated/floor/plating,/area/halo/interior)
 "tY" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 8},/turf/simulated/floor/wood/boat/starting,/area/halo/interior)
-"tZ" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 4},/turf/simulated/floor/wood/boat/starting,/area/halo/interior)
+"tZ" = (/obj/marker/map_node,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "ua" = (/obj/structure/interactive/potted_plant/office,/turf/simulated/floor/wood/rich,/area/halo/interior/comm_unsc)
 "ub" = (/obj/structure/smooth/table/wood,/obj/structure/interactive/computer/console/laptop{dir = 1; icon_state = "laptop"},/turf/simulated/floor/wood/rich,/area/halo/interior/comm_unsc)
 "uc" = (/obj/structure/smooth/table/wood,/turf/simulated/floor/wood/rich,/area/halo/interior/comm_unsc)
@@ -1173,7 +1168,7 @@
 "wC" = (/obj/structure/interactive/crate,/turf/simulated/floor/tile/command,/area/halo/interior/comm_unsc)
 "wD" = (/mob/living/advanced/npc/halo/kigyar{dir = 1; icon_state = "halo_kigyar1"},/turf/simulated/floor/plating,/area/halo/exterior/jungle)
 "wE" = (/obj/structure/smooth/table/glass,/turf/simulated/floor/tile/dark,/area/halo/interior/comm_unsc)
-"wF" = (/mob/living/advanced/npc/halo/marine{dir = 4; icon_state = "directional"},/turf/simulated/floor/tile/dark,/area/halo/interior/comm_unsc)
+"wF" = (/obj/decal/tile/cargo,/obj/marker/map_node,/turf/simulated/floor/tile/grey,/area/halo/interior/geminus/mining)
 "wG" = (/turf/simulated/wall/plastic/office/darker,/area/halo/interior/geminus/cargo)
 "wH" = (/obj/structure/interactive/construction/grille,/obj/structure/smooth/window/reinforced,/turf/simulated/floor/plating,/area/halo/interior/geminus/cargo)
 "wI" = (/obj/structure/interactive/chair/wood,/turf/simulated/floor/carpet,/area/halo/interior/bar)
@@ -1478,7 +1473,7 @@
 "Cv" = (/obj/structure/interactive/chair/stool,/obj/structure/interactive/lighting/fixture/tube/station{dir = 8},/turf/simulated/floor/tile/chapel{dir = 4; icon_state = "floor"},/area/halo/interior/geminus/church)
 "Cw" = (/mob/living/advanced/npc/halo/kigyar/ranged,/turf/simulated/floor/colored/ash/dark,/area/halo/exterior/jungle)
 "Cx" = (/obj/structure/interactive/atmospherics/air_alarm{pixel_x = -32},/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/core)
-"Cy" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/core)
+"Cy" = (/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior/geminus/car_storage)
 "Cz" = (/mob/living/advanced/npc/halo/marine{dir = 1; icon_state = "directional"},/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
 "CA" = (/obj/structure/smooth/table/rack/grey,/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/core)
 "CB" = (/obj/structure/smooth/table/rack/grey,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/core)
@@ -1506,7 +1501,7 @@
 "CX" = (/obj/structure/interactive/fence{dir = 4},/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "CY" = (/obj/structure/interactive/fence/corner{dir = 4},/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "CZ" = (/obj/structure/interactive/vending/engineering/wardrobe,/obj/structure/interactive/lighting/fixture/bulb{dir = 4},/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
-"Da" = (/obj/structure/interactive/atmospherics/fan,/obj/structure/interactive/barricade{dir = 1; icon_state = "metal"},/mob/living/simple/turret/unsc{dir = 1},/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
+"Da" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior)
 "Db" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 8},/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
 "Dc" = (/obj/structure/interactive/lighting/fixture/covenant{dir = 1; icon_state = "covie_light_on"},/turf/simulated/wall/covenant,/area/halo/interior)
 "Dd" = (/obj/marker/covenant/elite_m,/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
@@ -1526,6 +1521,8 @@
 "Dr" = (/obj/structure/interactive/fence,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "Ds" = (/obj/structure/interactive/lighting/fixture/floor/strong,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "Dt" = (/mob/living/advanced/npc/halo/unggoy,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
+"Du" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark/ish,/area/halo/interior)
+"Dv" = (/obj/marker/map_node,/turf/simulated/floor/tile/shuttle,/area/halo/interior)
 "Dw" = (/mob/living/advanced/npc/halo/elite,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "Dx" = (/obj/structure/interactive/crate/covenant,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "Dy" = (/obj/structure/smooth/table/wood/poor,/turf/simulated/floor/tile/chapel{dir = 8; icon_state = "floor"},/area/halo/interior/geminus/church)
@@ -1561,7 +1558,7 @@
 "Ec" = (/mob/living/advanced/npc/halo/marine{dir = 4; icon_state = "directional"},/turf/simulated/floor/colored/dirt/soil,/area/halo/exterior/jungle)
 "Ed" = (/obj/structure/interactive/computer/console,/obj/decal/hazard/black/box,/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
 "Ee" = (/obj/structure/smooth/table/reinforced,/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
-"Ef" = (/turf/simulated/floor/tile/dark/er,/area/halo/exterior/jungle)
+"Ef" = (/obj/structure/interactive/lighting/fixture/tube/station{dir = 4},/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior)
 "Eg" = (/obj/structure/interactive/barricade/covenant,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "Eh" = (/obj/decal/sidewalk/side{dir = 4; icon_state = "cobble_side2"},/mob/living/advanced/npc/halo/unggoy,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "Ei" = (/obj/structure/interactive/barricade/covenant{dir = 4; icon_state = "cov"},/mob/living/advanced/npc/halo/kigyar/ranged{dir = 4; icon_state = "halo_kigyar1"},/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
@@ -1581,7 +1578,7 @@
 "Ew" = (/obj/structure/interactive/vending/clothes/dye,/turf/simulated/floor/tile/dark,/area/halo/interior/bar)
 "Ex" = (/mob/living/advanced/npc/halo/marine{dir = 1; icon_state = "directional"},/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 "Ey" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
-"Ez" = (/turf/simulated/wall/metal/reinforced,/area/halo/exterior/jungle)
+"Ez" = (/obj/decal/sidewalk/side{dir = 1; icon_state = "cobble_side2"},/obj/marker/map_node,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "EA" = (/mob/living/advanced/npc/halo/kigyar{dir = 1; icon_state = "halo_kigyar1"},/turf/simulated/floor/wood/brown,/area/halo/interior/bar)
 "EB" = (/obj/structure/interactive/lighting/fixture/covenant{dir = 4; icon_state = "covie_light_on"},/turf/simulated/wall/covenant,/area/halo/interior)
 "EC" = (/obj/structure/interactive/computer/console,/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/church)
@@ -1623,110 +1620,162 @@
 "Fm" = (/obj/structure/interactive/barricade{dir = 4; icon_state = "metal"},/obj/structure/interactive/barricade{dir = 1; icon_state = "metal"},/mob/living/simple/turret/unsc{dir = 4},/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
 "Fn" = (/obj/structure/interactive/barricade,/obj/structure/interactive/barricade{dir = 8},/mob/living/simple/turret/unsc{dir = 8},/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
 "Fo" = (/obj/structure/interactive/barricade{dir = 4; icon_state = "metal"},/obj/structure/interactive/barricade,/mob/living/simple/turret/unsc{dir = 4},/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
-"Fq" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/turf/simulated/floor/tile/dark/er,/area/halo/exterior/jungle)
+"Fp" = (/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior)
+"Fq" = (/obj/decal/hazard/black{dir = 8; icon_state = "line"},/obj/marker/map_node,/turf/simulated/floor/plating,/area/halo/interior/geminus/car_storage)
+"Fr" = (/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
+"Fs" = (/obj/marker/map_node,/turf/simulated/floor/plating,/area/halo/interior/geminus/morgue)
+"Ft" = (/obj/structure/interactive/chair/wood{dir = 1; icon_state = "wooden_chair"},/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior/geminus/morgue)
+"Fu" = (/obj/marker/map_node,/turf/simulated/floor/carpet,/area/halo/interior)
+"Fv" = (/obj/decal/tile/nanotrasen,/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/car_storage)
+"Fw" = (/obj/structure/scenery/rocks,/obj/marker/map_node,/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
+"Fx" = (/obj/marker/map_node,/mob/living/advanced/npc/halo/kigyar/ranged,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
+"Fy" = (/obj/decal/tile/medbay,/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
+"Fz" = (/obj/marker/map_node,/turf/simulated/floor/wood/boat/starting,/area/halo/interior)
+"FA" = (/obj/marker/map_node,/turf/simulated/floor/tile/medical,/area/halo/interior/geminus/morgue)
+"FB" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/morgue)
+"FC" = (/obj/decal/tile/medbay,/obj/decal/tile/medbay{dir = 4; icon_state = "tile"},/obj/structure/interactive/lighting/fixture/tube/station{dir = 8},/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/geminus/morgue)
+"FD" = (/obj/decal/sidewalk/side,/obj/marker/map_node,/mob/living/advanced/npc/halo/marine{dir = 4; icon_state = "directional"},/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
+"FE" = (/obj/decal/sidewalk/side{dir = 1; icon_state = "cobble_side2"},/obj/decal/sidewalk/side,/obj/marker/map_node,/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
+"FF" = (/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior/comm_unsc)
+"FG" = (/obj/marker/map_node,/turf/simulated/floor/carpet,/area/halo/interior/comm_unsc)
+"FH" = (/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/geminus/medbay)
+"FI" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 4},/obj/marker/map_node,/turf/simulated/floor/wood/boat/starting,/area/halo/interior)
+"FJ" = (/obj/marker/map_node,/turf/simulated/floor/tile/grey,/area/halo/interior/comm_unsc)
+"FK" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior/comm_unsc)
+"FL" = (/obj/structure/interactive/lighting/fixture/tube/station{dir = 1},/obj/marker/map_node,/turf/simulated/floor/tile/command,/area/halo/interior/comm_unsc)
+"FM" = (/obj/marker/map_node,/turf/simulated/floor/tile/command,/area/halo/interior/comm_unsc)
+"FN" = (/obj/decal/tile/medbay,/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/geminus/medbay)
+"FO" = (/obj/decal/tile/medbay{dir = 8; icon_state = "tile"},/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/geminus/medbay)
+"FP" = (/obj/decal/sidewalk/corner{dir = 1; icon_state = "cobble_corner2"},/obj/marker/map_node,/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
+"FQ" = (/obj/marker/map_node,/turf/simulated/floor/tile,/area/halo/interior/comm_unsc)
+"FR" = (/obj/marker/map_node,/mob/living/advanced/npc/halo/marine{dir = 4; icon_state = "directional"},/turf/simulated/floor/tile/dark,/area/halo/interior/comm_unsc)
+"FS" = (/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior/bar)
+"FT" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/cargo)
+"FU" = (/obj/marker/map_node,/turf/simulated/floor/cobblestone,/area/halo/exterior/jungle)
+"FV" = (/obj/decal/sidewalk/side{dir = 8; icon_state = "cobble_side2"},/obj/marker/map_node,/turf/simulated/floor/brick/grey,/area/halo/exterior/jungle)
+"FW" = (/obj/marker/map_node,/turf/simulated/floor/cobblestone/side{dir = 1; icon_state = "cobble_side"},/area/halo/exterior/jungle)
+"FX" = (/obj/decal/sidewalk/side{dir = 4; icon_state = "cobble_side2"},/obj/marker/map_node,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
+"FY" = (/obj/marker/map_node,/turf/simulated/floor/tile/shuttle,/area/halo/interior/geminus/shuttle)
+"FZ" = (/obj/decal/hazard{dir = 4},/obj/marker/map_node,/turf/simulated/floor/plating,/area/halo/exterior/jungle)
+"Ga" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior/bar)
+"Gb" = (/obj/marker/map_node,/turf/simulated/floor/cobblestone/side{dir = 8; icon_state = "cobble_side"},/area/halo/exterior/jungle)
+"Gc" = (/obj/marker/map_node,/turf/simulated/floor/cobblestone/side,/area/halo/exterior/jungle)
+"Gd" = (/obj/structure/interactive/chair/wood{dir = 8; icon_state = "wooden_chair"},/obj/marker/map_node,/turf/simulated/floor/wood/rich,/area/halo/interior/bar)
+"Ge" = (/obj/decal/sidewalk/side{dir = 8; icon_state = "cobble_side2"},/obj/marker/map_node,/turf/simulated/floor/carpet/office,/area/halo/exterior/jungle)
+"Gf" = (/obj/marker/map_node,/mob/living/advanced/npc/halo/kigyar,/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
+"Gg" = (/obj/structure/interactive/lighting/fixture/bulb{dir = 1; icon_state = "preview"},/obj/marker/map_node,/turf/simulated/floor/tile/dark,/area/halo/interior/geminus/core)
+"Gh" = (/obj/marker/map_node,/turf/simulated/floor/covenant/blue,/area/halo/exterior/jungle)
+"Gi" = (/obj/marker/map_node,/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
+"Gj" = (/obj/structure/interactive/atmospherics/fan,/obj/marker/map_node,/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
+"Gk" = (/mob/living/advanced/npc/halo/unggoy{dir = 8; icon_state = "halo_unggoy"},/turf/simulated/floor/cave_dirt,/area/halo/exterior/jungle)
+"Gl" = (/mob/living/advanced/npc/halo/marine,/turf/simulated/floor/tile/dark/er,/area/halo/interior/geminus/core)
+"Gm" = (/obj/marker/map_node,/mob/living/advanced/npc/halo/unggoy{dir = 4; icon_state = "halo_unggoy"},/turf/simulated/floor/grass,/area/halo/exterior/jungle)
+"Gn" = (/obj/structure/smooth/table/reinforced,/turf/simulated/floor/plating,/area/halo/interior/geminus/core)
+"Go" = (/turf/simulated/floor/plating,/area/halo/interior/geminus/core)
+"Gp" = (/obj/decal/sidewalk/side{dir = 4; icon_state = "cobble_side2"},/obj/marker/map_node,/turf/simulated/floor/grass,/area/halo/exterior/jungle)
 
 (1,1,1) = {"
 mImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImJadadadadadadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImJadmKiXiXiXiXmLiXiXiXiXmMadmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmNmNmNmNmNmNmNmNmNmNmNmNmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadadadadadadadadadadadadadadadadadmPmQmRmQmSmTmUmTmSmTmTmSafafmVafmVafafmVmVmVmSmVafafafafmVmVmVmVmVmVmVafafmSadadadadadadadadadadmWmXmYmZnamWnbncmQndnendndndmQnendndndnfmOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadadgLngngngngngngngngngngngadadadmPmQnhmQmSmTmTmTmTmTmTmSafafmSmSmSmSmSmSninjmSafmVmVafafafafmVmVafmVmVafmVmSadadadadadiFkmnknlmWmWnmnnndnfnonpnhnqmWnrnsmWmWntmQmQmWnrnumOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadngnvnwnxmVmVmVnwmVmVmVmVnwnyngadmPmQmQnhmSmTmTmTmSmSnzmSmVmVmSadadadadadadadmSninjmSmSmSmSmSmSmSmSmSmSninjmSadiFadadadadkmmVafmVmWmWnAmWnBmWmWmQmWmQnCnDmWmWnDmQmWmWnDnDmOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdnEmVmVmVmVmVmVmVmVmVnFmVmVmVmVmVnGmPmQmQmQmSmTmTmTmTnHmTmSnInjmSadadadadadiFadadnJadadadadafadadadadadadadadadadadadadadadkmafafmVmWnKnLnMnNmWnOnOafafadadadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdnPmVmVmVnQnRnQmVnSmVnQnTnQmVmVmVnGmPnUmQmQmSmSmTmSmSmTmTmSadadadadadadadadadadadnVnVadnVafnVnVnVnVnVadadadadadadadiFadadadkmkmmVmVmWnWndnXnfnBadafadafadafadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdnPmVmVmVnQnYnQmVmVmVnQnZnQmVnFmVnGdsadadadadadoaadadadadadadadadadadadiFadadadafnVobocmQafodoemQofnVadadogadadadadadadadadadkmninjmWafmQmWmWmWadadafafafafadoamSmSmSmSmSohmNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadoimQmQmQmQmQmQmQmQmQojnPmVmVmVnQoknQmVmVmVnQolnQmVmVmVnGomonononononononooononononononadadadadiFadafafnVmQmQopgZoqororosnVadadadadadadadadadadadadadadadgNafafadafnOadotafouafafadadmSovowoxmSoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdnPmVmVnFmVmVmVmVmVnxmVmVmVmVmVmVnGomozoAonoBoCoCoCoDoCoooCoEoFonadadaeaeaeaeafadnVoGoHoInVoJororoenVnVnVnVnVnVnVnVnVadadadadadadgLadadafadadadadadafafoaadadadmSoKoxoxmSoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJiFjbmQmQmQmQmQmQmQmQmQjdadoLoMnwmVmVmVmVnwmVmVmVmVnwoNoLadomoAoAonoCoCoCoCoCoConoOoCoPonadaeaeaeaeaeaeadafnVoQnVnVnVoRnVnVnVoSoToUoUoUoUoVnVadadoWoXoXoXoXoXoXoXoXoXoXoXoXafoXoXmQadadmSmSoYmSmSoZmNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadadadoLoLoLoLoLoLoLoLoLoLoLadadadompaononoCpbonoOoCoConononononadgPaeaeaeaeaeafafpcorafpdpeosnVnVpfpgphpiphphpjpkpljFpmadoXpnpopppppppqpoproXpsptpuafpvoXadadmSpwoyoypxoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadadiFadadadadadadadadadadadadadadomoCoCoCoCoCoCoCoCoCoooCoEoFonadaeaeaeaeaeafgVnVafmQormQorornVpypzpApBpBpBpBpCpDpljFadadoXpEpFpFpGpGpHpFpIoXpJpKpLptpMoXadadmSpNpOoyohoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadadadadadadpPpPpPpPpPpPpPpPpPdsdsomoCoCoCoCoCoCoCoCoConoOoCoPonadaeaeaeaeaeaeafnVmQmQpQororornVpypzpApRpBpBpBpCpkpljFadadoXpEpFpFpGpSpFpFpIoXpLpTpLpUpVoXadadmSmSmSmSmSmSmNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadjbmQmQmQmQmQmQmQmQmQjdadadadadadpWpPpXpXpXpXpYpZpYkmadadonoCqaqboCpbonoOoCqconononononadaeqdaeaeaeaeadnVorqeoeorororqfpfqgqhqiqjqiqiqkpkpljFadadoXqlqmqnqoqoqoqoqpoXpsqqpspsqroXadfiadadadiFadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadqsjVjVjVjVqtjVjVjVjVquadadafafadadpPpXqvpXpXpXpXpXkmadadonoOqwqbqxoCoCoCqcoCoooCoEoFonadaeqdaeaeaeaeadnVqyoroeororqznVqAqBqBqBqBqBqBqBqCnVadadadoXoXqDqDqDoXoXqEoXqFoXqDqGqDoXoXoXoXoXoXoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadadadadadadadadadafiJafafafadpPqHpXpXpXpXpXpXkmadadonoCoCqboCoCoCoCoCoConoOafafafadaeaeaeaeqdaeadnVnVnVnVnVoRnVnVnVqInVnVnVqJqKqLnVnVadadadadadadadadadoXqMpopoqNqOpopoqPoXqQqRqSqQoXadiFadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNqTqTmPqTqTmPmPmPmPmPmPmPdgdgqUdgdgdspPpXpXpXpXpYqVpYkmadadononpxpxonooooonpxonononafafafadaeaeaeaeaeaeadadadadadadiTadadadiTadadadiTiTiTadadadadadadqWadadadadqXqYpFpFpFpFpFpFpIqZqSqSraqSqZadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmTmTrbrbmSmTmTafiJafadadkmkmrckmkmkmkmkmkmadadrdiFadadadadadadadadrerdadafadadqdaeaeaeaeaeadadadadadadadadadadadadadadadadadadadadadadadadadadadadrfqoqoqoqoqorgqorhoXriqSqSqSoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTrjmSmTmTmTmTmTmTrbmSmTmTmTmSadadadkmrkrkrkrlrmrlrkkmafadadadadadadadadadadadadadadadadaeaeaernaeaeaeaeadadadadadadadadadadadadadadadadadadadadadadadadadadadoXoXoXoXrooXoXoXoXoXrpqSqSrqoXadrradmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmTmTmTmTmSmTmTrbmSadadadkmrkrkrkrkrkrsafiJafgVadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeadadadadadadadadadadoaadoXrtrupoporvporwoXrpqSqSrpoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSrxmTmSmSmTrymSmSmTmTrzmSadadadkmrArkrkrkrBafrCafafafadaeaeaeaeaeaeaeaerDaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaernaeaeadoWadadadadadadadadadqDrErFrGpGrHrIrJoXqSqSrKqSoXpmadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmTmTmTmTmSmTrbrLmSadadpWkmrMrkrBrkrsrkafafiJadaeaeaeaeaegPaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaerNaeaeaeaeaeaeaeaeaerOaeaeaeaeaeaeadadadadadadadadadadqDrEpFpGrPrHpFpIoXrprKqSrpoXadpmadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSrQmTmSmTmSmSmSmSmTmSmSmSadadadkmrkrkrkrRrSrRkmafrdadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaerNaeaeaeaeaeaeaeaeaeaeaeaeaeaerTaeoWadadadadfiadadadadoXrUqoqoqoqoqorVoXrWqSrXrYoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadadadadadadadadadadadadadadadadadmSmQmRmQmSmTmUmTmSmTmTmSafafmVafmVafafmVmVmVmSmVafafafafmVmVmVmVmVmVmVafafmSadadadadadadadadadadmWmXmYmZnamWnbncmQndnendndndmQnendndndnfmOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadadgLngngngngnyngngngngngngadadadmSmQnhmQmSmTqqmTmTmTqqmSafafmSmSmSmSmSmSninjmSafmVmVafafafafmVmVafmVmVafmVmSadadadadadiFkmnknlmWmWnmnnndnfnonpranqmWnrnsmWmWntrVmQmWnrnumOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadngnvnwnxmVmVmVnwmVmVmVmVnwsongadmSmQrVnhmSmTmTmTmSmSnzmSmVmVmSaddeadadadadadmSninjmSmSmSmSmSmSmSmSmSmSninjmSadiFaddeadadkmmVafmVmWmWnAmWnBmWmWmQmWmQnCnDmWmWnDmQmWmWnDnDmOmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdnEmVmVmVmVmVmVmVmVmVnFmVmVmVmVmVnGmSmQmQmQmSmTmTmTmTnHmTmSnInjmSadadadadadiFadadnJaddeadadafadadaddeadadadadadadadadadadadkmafafmVmWnKnLnMnNmWnOnOafafadadadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdnPmVmVtZnQnRnQmVnSmVnQnTnQmVmVmVnGmSnUmQmQmSmSmTmSmSmTmTmSadadadadadadadadadadadnVnVadnVafnVnVnVnVnVadadadadadadadiFadadadkmkmmVmVmWnWwFnXnfnBadafadafadafadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdnPmVmVmVnQnYnQtZmVmVnQnZnQmVnFtZnGadadadaddeadoaadadadadaddeadadadadadiFadadadafnVobocmQafodoemQofnVadadogdeadadadadadadadadkmninjmWafmQmWmWmWadadafafafafadoamSmSmSmSmSohmNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadoimQmQmQmQmQmQmQmQmQojnPmVmVmVnQoknQmVmVmVnQolnQmVmVmVnGononononononononooononononononadadaddeiFadafafnVmQrVopgZoqCyorosnVdeadadadadadadadadadaddeadadadgNafafadafnOadotafouafafadadmSovowoxmSoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdnPmVmVnFmVmVmVmVmVnxmVmVmVmVmVmVnGonozoAonoBoCoCoCoDoCoooCoEoFonadadaeaeaeaeafadnVoGoHoInVoJororoenVnVnVnVnVnVnVnVnVadadadadadadgLadadafadaddeadadafafoaaddeadmSoKoxDamSDumNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJiFjbmQmQmQmQmQmQmQmQmQjdadoLoMnwmVmVmVmVnwmVmVmVmVnwoNoLadonDvoAonoCoCoCoCoCoConEfoCoPonadaeaeaeaeaeaedeafnVoQnVnVnVoRnVnVnVoSoToUoUoUoUoVnVadadoWoXoXoXoXoXoXoXoXoXoXoXoXasoXoXmQadadmSmSoYmSmSoZmNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadadadoLoLoLoLoLoLoLoLoLoLEzadadadonpaononoCpbonoOFpoConononononadgPaeaeaeaeaeafafpcorafpdpeosnVnVpfpgphpiphphpjpkpljFpmadoXpnpopppppppqpoproXpsptpuafpvoXadadmSpwDuoypxoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadadiFadaddeadadadadadadadadadadadonoCoCoCoCoCoCoCoCoCoooCoEoFonadaeaeaeaeaeafgVnVasmQormQorornVpypzFqpBpBpBpBpCpDpljFadadoXpEpFFrpGpGpHpFpIoXpJpKpLFspMoXadadmSpNpOoyohoymNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadadadadadadkmkmkmkmkmkmkmkmkmadadonoCoCoCFpoCoCoCoCoConoOFpoPonadaeaeaeaeaeaeafnVmQmQpQororornVpypzpApRpBpBpBpCpkpljFdeadoXpEpFpFpGpSpFFrpIoXpLpTpLpUpVoXaddemSmSmSmSmSmSmNmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadjbmQmQmQmQmQmQmQmQmQjdadadadadadpWkmpXpXpXpXpYpZpYkmadadonoCqaqboCpbonoOoCqconononononadaeqdaeagaeaeadnVorqeoeCyororqfpfqgqhqiqjqiqiqkpkpljFadadoXqlqmqnqoqoqoqoqpoXpsFtpspsqroXadfiadadadiFadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadqsjVjVjVjVqtjVjVjVjVquadadafafadadkmpXqvpXpXpXFupXkmaddeonoOqwqbqxoCoCoCqcoCoooCoEoFonadaeqdaeaeaeaeadnVqyoroeororqznVqAqBqBqBqBqBFvqBqCnVadadadoXoXqDqDqDoXoXqEoXqFoXqDqGqDoXoXoXoXoXoXoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJaddeadadadadadadadadadadafFwafafafadkmqHpXFupXpXpXpXkmadadonoCoCqboCoCoCFpoCoConoOafafafadaeaeaeaeqdaeadnVnVnVnVnVoRnVnVnVqInVnVnVqJqKqLnVnVadadadadadadadadadoXqMpopoqNqOpopoqPoXqQqRqSqQoXadiFadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmSmSmSmSmSmSmSmSmSafafafafafadkmpXpXpXpXpYqVpYkmadadononpxpxonooooonpxonononafasafadaeaeaeaeaeaeadadadadadadiTadadadiTadadadiTiTiTadadadadadadqWadadadadqXqYFrpFpFpFpFpFpIqZqSqSFxqSqZaddeadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTqqmSmTmTrbrbmSmTmTafiJafaddekmkmrckmkmkmkmkmkmadadrdiFadadadadadadadadrerdadafadadqdaeaeaeaeaeadadaddeadadadadadadaddeadadadadadadadadadadadadadadadadrfqoqoqoqoqorgFyrhoXriqSqSqSoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTrjmSmTmTmTmTmTmTrbmSmTmTmTmSadadadkmrkrkrkrlrmrlrkkmafadadadadadadadadadadadadadadadadaeaeaernaeaeaeaeadadadadadadadadadadadadadadadadadadaddeadadadadadadadoXoXoXoXrooXoXoXoXoXrpqSqSrqoXadrradmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSmTqqmTmTmSmTmTrbmSadadadkmrkFzrkrkrkrsafiJafgVadadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeadadadadadadadadadadoaadoXrtrupoporvporwoXrpqSqSrpoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNqqmTmSrxmTmSmSmTrymSmSmTmTrzmSdeadadkmrArkrkrkrBafrCafafafadaeagaeaeaeaeaeaerDaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaernaeaeadoWadadadadadadadadadqDrErFrGFArHrIrJoXqSqSrKFBoXpmadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSmTmTmTmTmSmTrbrLmSadadpWkmrMrkrBrkrsrkasafiJadaeaeaeaeaegPagaeaeaeaeaeaeaeaeaeaeagaeaeaeaeaeaerNaeaeaeagaeaeaeaeaerOaeaeaeaeaeaeadadadadadadadadadadqDrEpFpGrPrHpFpIoXrprKqSrpoXadpmadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSrQmTmSmTmSmSmSmSmTmSmSmSaddeadkmrkrkrkrRrSrRkmafrdadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaerNaeaeaeaeaeaeaeaeaeaeaeaeagaerTaeoWadadadadfiadadadadoXrUFyqoqoqoqoFCoXrWFBrXrYoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImNrZmTmSmTrQmSmTmTmTsamTmTrQmTmSadadadkmkmsbkmkmkmkmkmadadkUaeaeaeaeaeaeaeaeaeaescaeaeaeaeaeaeaeaeaerNaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeadadadadadadadadadadoXoXoXoXoXoXoXoXoXoXoXoXoXoXadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmTsdmTiJmTmTmTsemSadadadgLadsfadadsgshadadkUkUaeaeaeaeaeaeadadadadadadadadadadadadadadadadadadadadsiaeaesjaesksladadaeaeaeaeaeaeadadadadadadgLadadadoaadadadadadadadadadadadadqWadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNrxmTmSmTmTmSmTmTafafiJrZrbrbmSadsmsnsnsnsosnsnsnspsnsnkUkUrTaeaeaeaeadadsqsqsqsqsqsqsqsqsqsqsqsqsrsrsqsqsqsrsrsqadaefuaeafadadadadaeaeaejBaeadadadadgLadadadadadadadgLadadadssadadadadadstadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSsumTmSmSmSiJsvafmSmSmSmSadadadadadadadadadsfadadkUkUaerTaeaeaeadadsqswsxsysqszsAsBsCsCsDsqsEiwififiwiwsFsqafaeaeaeaeadadqWadaesGaeaegPadadsHsHsHsHsHsIsIsHsHsHsHsHsHsHsHsHsHsHsHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNsJmTmSmTmTmSmTrbmTafmSmTrbmTmSadadadkmsKsKsKkmkmsbkmkmadkUaeaeaeaeaeadadsqsysysysLsysMsMsMsMsCsqifsNsNsOsNsNifsqsqsPafafaemQsqadadaeaeaeaeaeadadsHsQsRsSsTsUsVsWsHsXsYsZtatbsHtcsUtdsHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmTmTmTmStemTtfmTmSmTrbsemSadiFadkmrltgthkmrktitjkmadadaeaeaeaeaeadadsqtksysysqtlsMsMsMsMtmsqiftntotptqsNtrsqadgNaftsaenGafafadaeaeaeaeaeadadsHtttutvtwtxtxtysHtztAtBtAtCtDtEtFtCsHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmTmTmTmSrbmTrbmTmTmTrQrbmSadadadkmrktGrkkmrkrktHkmadadaerTaeaeaeoaadsqsytIsysqtJsytKtLsysysqtrsNtMsMtNtOifsqtPtQadoLtRafmQadadaeaeaeaeaeadadsHtxtxsHtwtxtxtysHtEtStxtTtCtDtUtxtVsHadadfiadadnJmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmStWmTmSmSmTmTrbmSmTtXmTmSadadadkmrkrktYkmtZrkrkkmadadaeaeaeaeaeadadsquaubucsqsqudududsqsLsqiftntMuetNsNifsqadngngngngngmQadadaerTaeaeaeadadsHtxufuguhtxtxtysHtwtAtAtAtCtDtztxuisHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTrymSmTmTmTmTmSmTmTmTmSadadadkmrkrkrksbrkrkrkkmadadaeaesjaegPaeadsqsqsqsqsqififujifififsquktnulumunsNifsqsquoififupuqsqadadaeaerTaeaeadadsHurtxusutuuuuuvsHuwuxuuuyuzsHuAuuuBsHsHsHsHadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSrbrymSmSmSmSmTmSmSadadadkmrkrkrkkmrkuCrkkmadfiaeaeaeaeaeaeaeaeaeaeaesqifsNsNsNsNifsqiwsNsNsNuDsNifsquEuFiNiNafuGafadnJaeaeaeaeaeadadsHsHuHsHsHsIsIsHsHuIsHuHsHsHsHsHuHsHsHuJtdsHadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSrbmTmSmTsamTmTmTmSadadadkmkmkmkmkmkmrckmkmrdadaeaeaeaeaeaeaeaeaegPaesquKififififuKsquLiwififuMifuNsqifiNifuKmQafuOadadaeaeaeaeaeadadsHuPsUsUsUsUsUuQsUsUsUsUuRsUuSuTsUsUuUuVtCtDadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSrbuWmSrbmTmTmTmTmSadadadkmpYpXuXuYpXpXpXkmadadaeaeaeaeaeaeaeaegPaeaesqsqsquZsqsqsqsqsqsqsqvasqsqsqsqsqsquZsqsqvbsqadadaeaevcaeaeadadsHvdtAtAvetxtxtAvftxtxtxvgtAtAtxtxtxvhtAtCtDadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNrxmTmSmTmTmSrbmTmSrbmTmTmTmTmSadadadkmvipXpXpXafafvjkmadadaeaeaeaeaeaeaeaeaeaeaesqifvkififvlvmtrififififififififififififsqadadadadaeaeaeaeaeadadsHvnuuuuvouuuuuuuuvpvqvruuuuvsuuuuuuuuuuvtsHadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmTmTmSmTmTmTmTmTmSadadadkmvupXpXafpXpXvvvwadadaeaeaeaeaeaeaeaeaeaeaesqifsNifsNsNvmsNsNsNvxvyvyvzifsNsNifsNvAsqadadadadaeaeaeaeaeadadsHsHtDtDsHsHtDtDsHsHvBtCsHsHvCsHsHsHvCsHvDsHadhsnJmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmSmTmSmSmSmTmSafmSadadadkmpXpXpXvEuXafafvFadadaeaeaeaeaeaeaeaeaeaeaesqifsNifsqsqsqsqvasqsqsqsqsqsqsqsqifsNifsqadadadadaeaeaeaeaeadvGadadadadadadadadadsHtwvHsHtttxtxsHtxtxttsHadstadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmTmTmTsamTmTvIafafmSadadadkmkmkmkmkmkmvwvwvFadadaeaeaeaeaerTaeaerTaeaesqvJvKifsquovLvMififiwiwifvNvLifsqifsNifsqadadadadaeaeaeaeaeadadvOngngngngngngadadsHtwtCsHvPtxvQsHvQtxvPsHadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSrxmTmSsdmTmTmTmTmTafiJafiJadadadadadadadafafiJafafadaeaeaerTaeaeadadadadadsqifsNifvaifsNvRtOvSsNsNtnvMvTifvaifsNmQsqafadadadaeaeaeaeaeadnPvUvVvUvVvUvVvUvWadsHuAvXsHvYvZwasHwavZwbsHadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmSmTmTmSmSmSmSmSmSmSmSafafafadadadadadhsadadadafafadadaeaeaeaeaeadadsqsqsqsqsqifififsqifwcvMvMsqvMsqvMvMsNifsqmQifnUafwdadadadaeaeaeaeaeadnPvUwevUvVvUwfvUnGadsHsHsHsHsHsHsHsHsHsHsHsHadadfiadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadgLwgadadadadogadadadafafadadhsadadadadadadadadadadadaeaeaeaeaeadadsqwhwiwjsqsqwksqsqifwlsNsNsNwmsNwnsNwotrsqsqwpsqsqadafadadaeaeaeaeaeadnPvUvVvUvVvUvVvUnGadadadadadadadhsadadadadadfiadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadadadadadadadadwqspspwrspspspspspspspkUadadadadadadaeaeaeaeaeadadsqwswswswswswswisqwtsNsNsNsNsNsNsNwumQmQsqwvwwmQsqadadadadaeaeaeaeaeadadoLoLoLoLoLoLoLadadadadadadwxadadadadadadadadadadfimJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwywyisisiswywywyiswzwziswywywywywywywyaeaeaernadadrdadaeaegMaeaeadadsqwksqwswswswswssqifwAwBuoifififwCuNwAwDsqwEwFwvmQafadadadtsaeaeaeaeadadadadadadadadadadwGwGwHwGwGwGwHwHwHwGwGwGwHwGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyhSwIwIwJhSwKwLwMwJwJwJwNwywOwPwQwRwyaeaeaeaeadadadpmaeaeaeaeaeadadsqwSsqwTwUwswUwssqukififsqwVvawVsqmQifwWafafmQwXafadadadadaeaegMaeaeadvGadwYwYwZaeaeaeaewGxaxbxawGxaxaxbxaxawGxaxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyxcxdxdxdhShShSwJwJxewJiawyxfxgxhxiwyaeaeaeaeaewgadadaeaeaeaeaeadadsqsqsqsqsqsqsqsqsqwVwVsqsqvGadadsqsqwVafafsqsqafafafadadadaeaeaeaeaeadadrdwYaeaeaerOaeaewHxaxbxbwGxaxbxbxaxbwGxaxbxawHadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyxjxkxlhShSxmxnhShShShSxowywOxhxhxpwyaeqdaeaeaeadadadaeaeaeaeaeadadadadadadadadadadadadadsgadadadadshreadadxqafadadadbkadadadaeaeaeaeaeadadadwYaeaeaeaeaeaemQxaxbxrwGxsxaxbxaxtwGxuxbxrwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyhShShQhQwJwJhQwJxvhQhQxwwyxxxhxhxywyaeaeaeaeaeadadaeaeaeaeaeaeaeadadadadadadadadadadadafadafbkafxzadafadafafafadadafafafadaesjaeaeaeaeaeadadadaeaeqdaeaeafafafxbxAwGxaxbxbxbxawGxaxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyhSwywOwOwOwywOwOwywOwOwOwywyxhxhxhwyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaegOcBaeaeaexBafafaeaeqdaernafafafqdafafaeaeaeaeaeaeaetsaeaeaeaeaeaeaeaeaeafafxCafxbmQwGxbxaxbxbxawGxbxbxawGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyhSwyxhxhxhxDxhxhxDxhxhxhxhwyxhxhxhwyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafafafafaeqdaeaeaeafafaeaeafafafafaeaeaeaeaeaeaeaeaeaeaerOaeaeaeafafafafxbxtwGxsxbxbxaxrwGxsxbxtwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwyxExFxhxhxhxhxhxGxhxhxHxhxhxIxhxhxhwyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaernaeaeaecBaeafafafaeaeaeaeafafaeaeaeaeaeaeaeaeaeaeaeaerOaeaeafafxJxbmQxawGxaxaxbxKxawGxbxKxawHadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSqqsdmTiJmTqqmTsemSadadadgLadsfadadsgshadadkUkUaeaeaeaeaeaeadadadadadadadadadadadadadadadadadadadadsiaeaesjaesksladadaeaeaeaeaeaeadadadadadadgLadadadoaadadadadadadaddeadadadadqWadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNrxmTmSmTqqmSmTmTafafiJrZrbrbmSadsmsnsnsnFDsnsnsnspFEsnkUkUrTaeagaeaeadadsqsqsqsqsqsqsqsqsqsqsqsqsrsrsqsqsqsrsrsqadaefuaeafadadadadaeaeaejBaeadadadadgLadadaddeadadadgLadadadssadadadadadstadaddeadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSsumTmSmSmSiJsvafmSmSmSmSadaddeadadadadadadsfadadkUkUaerTaeaeaeadadsqswsxsysqszsAsBsCsCsDsqsEiwififiwiwsFsqafaeaeagaeadadqWadaesGaeaegPadadsHsHsHsHsHsIsIsHsHsHsHsHsHsHsHsHsHsHsHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNsJmTmSmTmTmSmTrbmTafmSmTrbmTmSadadadkmsKsKsKkmkmsbkmkmadkUaeaeaeaeaeadadsqsysysysLFFsMsMsMsMsCsqifsNsNsOsNsNifsqsqsPafafaemQsqadadaeaeaeaeaeadadsHsQsRsSsTsUsVsWsHsXsYsZtatbsHtcsUtdsHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmTmTmTmStemTtfqqmSmTrbsemSadiFadkmrltgthkmrktitjkmadadaeaeaeaeaeadadsqtkFFsysqtlsMsMFGsMtmsqiftntotptqsNtrsqadgNaftsaenGafafadaeaeaeaeaeadadsHtttutvtwtxtxtysHtztAtBtAtCtDtEtFtCsHdeadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNqqmTmTmTmTmSrbmTrbmTmTmTrQrbmSadadadkmrktGrkkmrkrktHkmadadaerTaeaeaeoaadsqsytIsysqtJsytKtLsysysqtrsNtMsMtNtOifsqtPtQadoLtRafmQadadaeaeaeaeaeadadsHFHtxsHtwFHtxtysHtEtSFHtTtCtDtUtxtVsHadadfiadadnJmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmStWmTmSmSmTmTrbmSmTtXmTmSadadadkmrkFztYkmFIrkrkkmadadaeaeagaeaeadadsquaubucsqsqudududsqsLsqiftntMuetNsNifsqadngngngngngmQadadaerTagaeaeadadsHtxufuguhtxtxtysHtwtAtAtAtCtDtzFHuisHadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTrymSmTqqmTmTmSmTqqmTmSdeadadkmrkrkrksbrkrkrkkmadadaeaesjaegPaeadsqsqsqsqsqififujifififsquktnulumunsNifsqsquoififupuqsqadadaeaerTaeaeadadsHurtxusutuuuuuvsHuwuxuuuyuzsHuAuuuBsHsHsHsHaddeadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSrbrymSmSmSmSmTmSmSadadadkmrkrkrkkmrkuCFzkmadfiaeaeaeaeaeaeaeaeaeaeaesqifFJsNsNsNifsqiwsNsNsNuDsNifsquEuFFKiNafuGafadnJaeaeaeaeaeadadsHsHuHsHsHsIsIsHsHuIsHuHsHsHsHsHuHsHsHuJtdsHadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTqqmSmTmTmSrbmTmSmTsamTmTmTmSadadadkmkmkmkmkmkmrckmkmrdadaeaeaeaeaeaeaeagaegPaesquKififififFLsquLiwififuMifuNsqifiNifuKmQafuOadadaeaeaeaeaeadadsHuPsUsUsUsUsUuQsUsUsUsUuRsUuSuTsUsUuUuVtCtDadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSrbuWmSrbmTmTmTmTmSadaddekmpYpXuXuYpXpXFukmadadaeaeaeaeaeaeaeaegPaeaesqsqsquZsqsqsqsqsqsqsqvasqsqsqsqsqsquZsqsqvbsqadadaeaevcaeaeadadsHvdtAtAveFHtxtAvftxtxtxvgtAtAtxFHtxvhtAtCtDadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNrxmTmSmTmTmSrbmTmSrbmTmTqqmTmSadadadkmvipXpXpXafafvjkmadadaeaeaeaeaeaeaeaeaeaeaesqifvkififvlvmtrFMifififififififififififsqadadadadaeaeaeaeaeadadsHvnFNuuvouuuuuuuuvpvqvruuuuvsuuuuuuuuFNvtsHadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSqqmTmSmTmTmTmTmTmSadadadkmvupXpXafFupXvvvwadadaeaeaeaeaeaeaeaeaeaeaesqifsNifsNsNvmsNsNsNvxvyvyvzFMsNsNifFJvAsqadadadadaeaeaeaeaeadadsHsHtDtDsHsHtDtDsHsHvBtCsHsHvCsHsHsHvCsHvDsHadhsnJmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNqqmTmSqqmTmSmSmTmSmSmSmTmSafmSaddeadkmpXFupXvEuXafafvFadadaeaeaeaeaeaeaeaeaeaeaesqifsNFMsqsqsqsqvasqsqsqsqsqsqsqsqifsNifsqadadadadaeaeaeaeaeadvGadadadadadadadadadsHtwvHsHtttxtxsHtxtxttsHadstadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmTmTmTsamTmTvIasafmSadadadkmkmkmkmkmkmvwvwvFadadaeaeaeaeaerTaeaerTaeagsqvJvKifsquovLvMififiwiwifvNvLifsqifsNifsqadadadadaeaeagaeaeadadvOngngngngngngadadsHFOtCsHvPFHvQsHvQFHvPsHadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSrxmTmSsdmTmTqqmTmTafiJafiJadadadadadadadafafiJafafadaeaeagrTaeaeadadadadadsqifsNifvaifsNvRtOvSFJsNtnvMvTFMvaifsNmQsqafadadadaeaeaeaeaeadnPvUvVvUvVvUvVvUvWadsHuAvXsHvYvZwasHwavZwbsHadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmSmTmTmSmSmSmSmSmSmSmSafafafadadadadadhsadadadafafdeadaeaeaeaeaeadadsqsqsqsqsqFMififsqifwcvMvMsqvMsqvMvMsNifsqmQifnUaswdadadadaeaeaeaeaeadnPvUwevUvVvUwfvUnGadsHsHsHsHsHsHsHsHsHsHsHsHaddefiadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadadgLwgadadadadogadadadasafadadhsadaddeadadadadadadadadaeaeaeaeaeadadsqwhwiwjsqsqwksqsqifwlsNsNsNwmsNwnsNwotrsqsqwpsqsqadafadadaeaeaeaeaeadnPvUvVvUvVvUvVvUnGadadadadaddeadhsadadadadadfiadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJaddeadadadadadadadadadFPspspwrspspspspspspspkUadadadadadadaeaeaeaeaeadadsqFQwswswswswswisqwtsNFJsNsNsNsNFJwumQmQsqwvwwmQsqadadadadaeaeaeaeaeadadoLoLoLoLoLoLoLadadadadadadwxadadadadadadadadadadfimJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwywyisisiswywywyiswzwziswywywywywywywyaeagaernadadrdadaeaegMaeaeadadsqwksqwswswsFQwssqifwAwBuoifififwCuNwAwDsqwEFRwvmQafadadadtsaeaeaeaeadadadadadaddeadadadwGwGwHwGwGwGwHwHwHwGwGwGwHwGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyhSwIwIwJhSwKwLwMwJwJwJwNwywOwPwQwRwyaeaeaeaeadadadpmaeaeaeaeaeadadsqwSsqwTwUwswUwssqukififsqwVvawVsqmQFMwWafafmQwXafadadadadaeaegMaeaeadvGadwYwYwZaeaeaeaewGxaxbxawGxaxaxbxaxawGxaxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyxcxdxdxdhXhShSwJwJxewJiawyxfxgxhxiwyaeaeaeaeaewgadadaeaeaeaeaeadadsqsqsqsqsqsqsqsqsqwVwVsqsqvGdeadsqsqwVafafsqsqafafafadadadaeaeaeaeaeadadrdwYaeaeaerOaeaewHxaxbxbwGxaxbxbxaxbwGxaxbxawHadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyxjxkxlhShSxmxnhShShXhSxowywOxhFSxpwyaeqdaeaeaeadadadaeaeagaeaeadadadadadadadadadadadadadsgadadadadshreadadxqafadadadbkadadadaeaeagaeaeadadadwYaeaeaeaeaeaemQxaxbxrwGxsxaxbxaxtwGxuFTxrwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyhShShQhQwJwJhQwJxvhQhQxwwyxxxhxhxywyaeaeaeaeaeadadaeaeaeaeaeaeaeadadadadadadadadadadadafadafbkafxzadafadafafasadadafafafadaesjaeaeaeaeaeadadadaeaeqdaeaeafafafxbxAwGxaxbxbxbxawGxaxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyhSwywOwOwOwywOwOwywOwOwOwywyxhxhxhwyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaegOcBaeaeaexBafafaeagqdaernafafafqdafafaeaeaeaeaeaeaetsaeaeaeaeaeagaeaeaeafasxCafFTmQwGxbxaFTxbxawGxbxbxawGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyhXwyxhxhxhxDxhxhxDxhxhxhxhwyxhxhxhwyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeafafafafaeqdaeaeaeafafaeaeafafafafaeaeaeaeaeaeaeaeaeaeaerOaeaeaeafafafafxbxtwGxsxbxbxaxrwGxsxbxtwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwyxExFFSxhxhxhxhxGxhFSxHxhxhxIxhFSxhwyaeaeaeaeaeaeagaeaeaeaeaeaeaeagaeaeaeaeaeaeaeagaeaeaeaernaeaeaecBaeafafafaeaeaeaeafafagaeaeaeaeaeaeaeagaeaeaerOaeaeafafxJxbmQxawGxaxaxbxKxawGxbxKxawHaddemJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImJadadwywywyxhxLxMwOxixNxhxiwOwOxhwyxOxPwOwyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaegOafaeaeaeaeafafaeaeaeaeaeafafafaeaeaeaeaeaeaeaeaeaeaeaewZaeaeaeaeaeaewGxaxbxbwGxaxbxKxaxawGxaxQxawGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadwywywywywywywywywywywywywywywywywyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaegPaeaeaeafaeaeafaeafaeafafaeaeaeaeaeaeaeaeaefuaefuaeaeaeaeaewZaeaeaeaeaeaewGwGxbwGwGwGwGxbwGwGwGwGxbwGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadadadadadadadadiFgLadadwqspspspspxRspkUkUadadadadaeaeaeaeaeaeaeadngngngngngngngngngngngafafxSxSngngngafadngadngngngngngadaeaeaefuaeaeaeadadwYwZwZaeaeaeaewGxbxbxbxbxbxKxTxbxbxbxUxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmSmSmSmSmSmSadadadadadadadadadxVkUxWxWxWxWxWxWxWadadadadadaeaeaeaeaeadnvmVmVmVmVmVwfmVxXmVafmVafafxSxYmVmVmVafafafafwfvUmVxZmVyaadaeaeaeaeaeadnJadadadaeaeaeaeaewGybxKxbxbxbxbxbxbxKxbxbxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJaddeadadwywywywywywywywywywywywywywywywywyaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaegPaeaeaeafaeaeafaeafaeafafaeaeaeaeaeaeaeaeaefuaefuaeaeaeaeaewZaeaeaeagaeaewGwGxbwGwGwGwGxbwGwGwGwGxbwGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadadadadadadadadadadiFgLadadwqspspspspxRsplckUadadadadaeaeaeaeaeaeaeadngngngngngngngngngngngafafFUxSngngngafadngadngngngngngadaeaeaefuaeaeaeadadwYwZwZaeaeaeaewGxbxbxbxbxbxKxTxbxbxbxUFTxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmSmSmSmSmSmSaddeadadadadadadadFVkUxWxWxWxWxWxWxWadadadadadaeaeagaeaeadnvmVmVmVmVmVwfmVxXmVafmVafafxSxYmVmVmVafafafafwfvUmVxZmVyaadaeaeagaeaeadnJadadadaeaeaeaeaewGybxKxbxbxbxbxbxbxKxbxbxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImNrbrbycrbmTmSvGadadadgjadrdadadxVydwywywywywywywywywywyrdadaeaeaeaeaenPmVmVmVmVmVmVmVmVmVmVmVwfafyexSxYmVmVweyfafmVmVmVmVmVvVmVmVnGaeaeaeaeaeadadadadadadadadadadwGxbwGwGxsygxbxbxbxbxrwGwGxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmTmTmTmTadadadadadpmadadadxVydwyyhyhhlyhyhhlyhyhwyngadaeaeaeaeaenPmVwemVmVmVmVmVwfmVmVyixZyjyexSykwfmVmVvVmVafwfmVmVmVyimVmVnGaeaeaeaeaeadiWiXiXiXiXiXiXiYiFwGxbwGwGxaxbxbxbylxbxbwGwGxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTrbmTmTmTmSadadadadymngngngadxVynwyyohmhmhmhmhmhmypwymVnGaeaeaeaeaenPxXmVwfyqyrysyrytyryryryryrxSxSxSyryryryryryryryryryumVwfmVnGaeaeaefuaeadjbyvyvyvyvyvyvjdadwGxbxbywxaxbxbyxxbyyxbywxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTmTmTrbmSfiadadnPvUyzvUxXnGxVydwyhmhmhmhmhmyAyBhmismVnGaeaeaeaeaenPmVmVvUyexSxSxSxSxSxSyCxSxSxSxSxSxSyDyDyDyExSxSxSxSxYmVmVvUyFaeaeaeaeaeadyGyvyHyIyIyJyvjdadwGxbxbxaxaxbylwGxbyyyKyLyMxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTmTrbmTrbmSadadyNwyisisisiswyyOyOwyyPyPyQwyyRyShrhmismVnGaeaeaeaeaexSyryryrxSxSxSonononononononononxSxYadadafyexSxSxSxSxSyryryrxSaeaeaeaeaenJyGafafyIyIyIyTjdadwGwGxbxbxbxbxbywxbyyyyyyyywGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTrbrbrbmTmSadadwyxhxhxhxhyUyVxhxhwRxhxhxhyWhmhthuhmismVnGaeaeaeaeaexSyDyDyDxSxSxSonmTmTmTonyXyYyZonzazbafadadyexSxSxSxSxSyDyDyDxSaeaeaeaeaeadyGafafyIyIyIyIjdadwGxbxbxbxbxbxbxbxbxbxbxbxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmTrbmTrbmTmSadadwyzcxhxhxhxhxhxhxhyUxhxhzdwyhmhmhmypwymVnGaeaeaeaeaenPzemVmVyexSxSonononononzfmTzgonxSxYzhafafyexSxSxSxSxYmVmVzinGaeaeaeaeaeadjbafyHyHyIzjyvzkadwGxbxbxbxTxbxbxbzlxbxbxbzmxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImNmSmSmSmSmSmSadadwyxhxhznzozoxgxhznzozoxgxhwywywyzpwywyzqadaeaeaeaeaenPmVmVmVyeyDxSonzrzsztonmToCzfonxSxSyryryrxSxSxSxSyDxYwfmVxXnGaeqdaeaeaepmjbyvzuyIyIzvyvjdadwGxbzwyxxbxbxbxbxbzlxbyxxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadadadadoWyOxhxhznzozoxgxhznzozoxgxhwyzxhEhEzywyadadaeaeaeaeaenPmVmVmVzzmVyeonzrzAmTononzBonononzCononxSxSxSxSxYxXzDmVnxmVnGaeaernaeaeadjbyvyIyIyIzvafjdadwGwGwGwGwGwGxbxbxbwGwGwGwGwGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadadadadadyOxhzExhxhxhxhxhxhzFxhxhxhwyzxhEhEhEafadwYaeaeaeaerTnPmVwfmVzzvUyeonzroCoConzGzGzHzGzGzGzGonxSxSxSxSzImVzJmVmVmVnGaeaeaeaeaeadjbyvyIyHyIzvafzKadadadadadadwGwGzLwGwGiFadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadwywyisisisiswywywyzcxhxhzMxhxhxhxhxhzdwywyzNzOhEafafvwaeaeaeaeaenPwemVzizzvVyeonmToCzPzBzGzGzGzGzGzHzGonxSxSxSxSzQvUzDmVmVmVnGqdaeaeaeaeadjbyvyIyHyJyJyvjdadngngngzRngadadadadiFadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadzSwyxDxhxhzExhxDxhxhxhxhxhxhzTxhxhzUxhxhxHwyzVhEafafafvwaeaeaeaeaezWxZmVmVzzmVyeonzXzYmTonzZAaAbAbAbAcAdonxSxSxSxSxYzizDmVwfmVnGaeaeaeaeaeadjbyvyvyvyvyvyvjdnPmVmVmVmVmVnGadiWiXiXiXiXiXiXiYadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadcewyxhxhznzozoxgAexhznzozoxgxhznzozoxgxhzdwywyhEgNafafvwaerTaeaeaenPmVmVmVzzmVyeonononononAfAgAhAhAhAiAfonxSAjxSxSxYvUzDmVmVmVnGaeaeaeaeaeadjbyvAkAkAkAkyvjdnPmVnFmVmVmVnGadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadyOxhzExhxhxhxhxhxhxhxhxhxhxhxhxhxhxhxHxhwyzxhEAlwyafadaeaeaeaeaenPmVAmmVyeyrAnxSxSxSxSxSxSxSxSAoxSzaxSxSxSxSxSxSxSyrxYmVwfvVnGaeaeaeaeaeadjbApApApApApApjdnPmVmVmVmVmVvWadjbmQmQmQmQxAmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadAqwyxhArxhxhArxhxhxhxhxhxGxhxhArxhxhxhxhxhwyAshEhEhEadadaeaeaeaeaenPmVxXwfyexSxSxSxSyDAtxSAuAuAvAuxSAuAuxSyDyDxSxSAjxSxYmVmVmVnGaeaeaeaeaeadjUjVjVjVjVjVjVAwadoLoLoLoLoLadadAxmQmQmQmQmQmQAyadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadzSwywywyyOyOwywywyxhxhxhxNxhwywywyyOyOwywywyzxzxzxwypmadaeaeaeaeaexSyryryrxSxSxSAnxYmVmVyeAuAuAzAuxSAuAuxYwemVyeAjxSxSxSyryryrxSaeaeaeaeaeadadadadadadadogadadadadpmpmadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadcewyxhxDxhxhxDxhwyxhznzoAAxhwyxhxhxhxhxhxhwywywywywyadadaeaeaeaeaexSyDyDABAnxSxSxSACzimVyeAuAuxSAuxSAuAuADxXmVyexSxSxSAEyDyDyDxSaeaeaeaejBadngononononononononononngadadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJdsdsAFxhznzozoxgxhwyxhznzoAAxhwyxhznzozoxgxhwyAGAGAGwyadadaeaeaeaeaenPmVmVmVyeAHxSxSxSyumVyeAuAuxSAuAzAuAuxYmVyqxSxSxSAExYvVmVmVnGaeAIaeaeaenPyjonAJAKAKALoyAMAKANonAOnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadAFzcznzozoxgzdwyzcznzoAAzdwyzcznzozoxgzdwyAGAGAGwyrdadaeaeaeaeaenPwfmVmVAPyDyDAnxSyDAQyDyDARyDyDyDyDyDyDAQyDxSxSyDASATmVmVxXnGaeaeaeaeaenPmVpxoyoyAUoyoyoyoyAVpxmVnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadAFxhznzozoxgxhAWxhznzoAAxhwyxhznzozoxgxhwyAGAGAGwyadfiaeaeaeaeaenPvUmVmVmVzimVyexYxZmVwfmVmVAXAOmVmVmVvVmVwfyeAYwfmVmVmVmVmVnGaeaeaeAIaenPmVpxoyoyAZAKAKAKBaoypxmVnGrradadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJBbBbBcxhxhxhxhxhxhAWxhxhxhxhxhwyxhxhxhxhxhxhwyAGAGAGwyadadaeaeaeaegPnPxZmVmVmVmVvUyeBdmVwfxXmVmVmVmVmVmVmVvVAOmVyexYmVmVmVmVmVBenGaeaeaeaeaenPmVpxBfoyAKAKAKAKBaBgpxmVnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJpmadBcBcBhBhBhBhAFAFAFBhBhBhBcAFAFBhBhBhBhAFAFAFAFAFAFadadgOaeaeaeaenPmVziwfmVvUmVyexYmVmVmVmVmVmVvVAOwfmVmVBimVyexYmVvVmVvUwfmVnGaeaeaeaeaenPmVonAKBjBkoyoyBkoyBlonmVnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadnPmVmVAmmVmVmVBmmVmVmVmVmVBmmVmVmVmVmVnGadstadaddsadadaeaeaeaeaeadoLoLoLoLoLoLxSxSoLoLoLoLoLBnoLoLoLoLBooLoLxSxSoLoLoLBpoLoLadaeaeaeaeaehsoLonpxpxonBqBqonpxpxonoLadadadadjbBrmQmQBrmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJBsadadoLBtoLoLBuoLadoLoLoLoLoLngBvBvBwBvBvngadadadBxdsadadaeaeaeAIaeaeadadadadadadxSxSadhsadadadadadrradadadadadxSxSadadadadadadaeaeaeaeaeaeadddadadadByadadafadadadadadadadadjUjVBzjVjVjVjVjWadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadBsadBsadadBAadadBAadBsnPmVmVmVBBmVmVmVnGvGadaddshsadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaetsaeaeaeaeaeaeadadadadadBCgLafadadadadadadadadoaadadadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadafBsadadadadBbBbBbadadadngBDBDBEBDBFBDBEBDBDngadvGdsadadaeaeBGaeaeaeAIaeaeaeaeaeaeaeaeaeaeaeaeaejBaeaeaeaeaeaeaeaeaeaejBaeaefuaeaegMaeaeaeadadBHBHBHBHmQafBImQBHafBHBHBHadkmnkBJkmadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadBKBKBLafBMBNBKBOBKBKBKnPmVBDBPBQBRBSBRBTBUBDmVnGaddsadadaeaeaeaeaeaeaeaeaeaeaeaejBaejBaesjaeaeaeaeaerTaeaeaeaeaeaeaeaeaefuaeaeaeaeaeaeaeaeadhsBHBVBWBWBHBIafafafoIBXBYBHadBZafafCaadCbCbCbCbCbCbCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadBKBOBOCdBMBOBKmQCeCfCgChCiBECjCkBSBSBSCjCkBEmVnGaddsadadadaeaeaeaeBGaeaeaeaeaeaeaeaeaeaefuaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeadadadBHClBXBXCmmQocafmQBXBXBWBHddCnafafCnadCbhlhmhmhnhoCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJBsBOBOCgBKCeBOComQCpCqadadmVBDCrCsCtCtBSCuCvBDmVnGaddsadrdadadaeaeAIaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeCwaeaeaeaeaeaeaeaeaeaeadadadadBHCxCyBXBHmQCzmQBHBYCACBBHadkmmVafkmadCbhphmhqhrhmCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJafBOBMBKBKBKBMBOBLadafadCCmVBECjCkBSBSCtCjCkBEmVnGaddsadadadadadadngngngadngngngadadadadaeaeaeaeaeadadadadadadadadadadadadadadadadadadadadadrdadBHBHBHBHBHBHCDBHBHBHBHBHBHadCEafmVCFadCbhmhmhthuhmCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJafafBOCeBKCgBOCGafafadadnPmVBDCuCsCtBSBSCuCsBDmVnGaddsadadadadadnPmVmVmVBmmVmVmVnGadadadaeaeaeaeaeadadadadadadadafafadafadadadadadadadadadadadadadBHBHCHBICIBICJCKBIBHBHadCLCnnInjCnadhvhnhmhmhnhmCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJafBKCpmQCMBOCNBKafCOCPCOadoLBDCQCRCSCTCSCQCRBDBDBDBDCUadwywywyCVwywyisisisisiswywywyadadaeaeaeaeaeadadCWCXCXCXCXCXafafafCXCXCXCXCXCXCXCXCXCXCXCYadBHBHCZBIBHDaBHBIDbBHBHadadCLadadadadCbhwhxhmhmhyCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJafBKDcafCdBOBKBKDdadadadDeadBDDfDgDhDiDjDhDkBDDlDlDlCUadwyDmhHDnAGhHhHhHhHhHDoDpDqwyCLadaeaeaeaeaeadadDrDsmVmVmVmVafafmVDtDsmVmVmVmVyjmVmVmVDsDrafEzEzBHBIBIBIBIBIBHBHBHDwadCbCbCbCbCbCbCbCbCbhzCbCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadafafafadBsadadadadDxadadBsBDBSDyCRBSCQDzBSBDDlDlDlCUadwyDohHDAhHAGhHhHAGhHhHAGDBwyadaeaeaeaeaeaeaeadDrmVDDDDmVDDafDEDDDDmVDDDDmVDDDDmVDDDDmVDradEzBHBHBHDFBIDGBHBHBHBHadadCbhAhmhmhvhBCbhChDhEhFCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadocafadDHDIDIDIDJDIDIDKadBDBSBSBSDLBSDMBSBDDlDlDlCUadwywywywywywyDNDODODOwyxIwywyadaeaeaeaeaeaeaeadDrmVDDDDmVDPDDmVDDDDmVDDDDmVDDDDmVDDDDmVDradBHEzBHBHBHCDBHBHBHBHBHiFadCbhGhnhmCbCbCbhEhHhIhECcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJDQBJkmBsadDRmVmVmVmVDSDTDUadBDBDBDDVBDBDBDBDBDBDBDBDCUadwyDWDXwODYwyhEAGDZhEwyxhEawyadaeaeaeaeaeaeaeadEbyiDDDDmVDDDDDtDDDDmVEcDDmVDDDDmVDDDDmVDrssBHBHEdEeBIBIEfEeEeBHBHadadCbhKhmhmhvhLCbhMhNhOhPCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJmVafBKEgEgDRmVmVmVmVDSmVEhadEiadadadadadadadadadadaddsadwyzcEjxhxhxIAGhEhEhExIxhEkwyadaeaeaeaeaeaeaeadElmVDDDDmVDDDDmVEmDDmVDDDDmVDDDDmVDDDDmVDradBHBHEnBIBIEoBIEfCJBHBHadadCbCbhvCbCbCbCbhQEphQhRCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJmVafBKadadDRmVmVmVmVmVmVDUadBDBDBDBDBDBDBDEqBDBDBDBDCUadwyErwOEswRwyEtEuEvEwwywywywyadaeaeaeaeaeaeaeadDrmVDDDDmVDDDDExDDDDmVDDDDmVDDDDnxDDDDmVDradBHBHBICJEyBIFqEfBIBHBHadadCbhSxkhThShUhVhSEAhShSCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJafmVEBadadDRmVmVmVmVDTmVDUEgBDECEDEEEFBDEGEEBDEHEHEHCUadwywywywywywywywywywywyhsadadadaeaeaeaeaeaeaeadDrmVDDDDmVDDDDmVDDDDExDDDDmVDDDDmVDDDDmVDradBHEIBIEJBHEKBHEJELEMBHogiFCbxkhXhSENhShShShShXhYCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJafafBKadadDRmVmVmVmVmVmVDUadBDEOEEEEEEEqEEEEEqEEEEEPCUadadadadadwxadadadadadadadadhsadaeaeaeaeaeaeaeadDrDsmVmVmVmVmVmVmVmVDsmVmVmVmVmVmVmVmVDsDradBHBHBIDbBHBHBHEQBIBHEzadadCbhZiaiaibhZicidibhSieCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJmVmVkmadadDRmVmVmVmVDSDtDUadBDEEEEERESBDETEUBDEHEHEHCUadadadadadadadadadadadadkmkmadadaeaeaeaeaeaeaeadEVCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXEWddBHBHBIBIBIBIEfEfEfEzEzadadCbijiaikibiliaiaibEXimCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJniEYBKadadEZFaFaFaFaFaFaFbadBDBDBDBDBDBDBDBDBDBDBDBDCUadadkmkmkmkmkmkmadadadkmkmadadadaeaeaeaeaeaeaeadadadadadadadadadadadadadadadadadadadadadadadBHBHBHBHBHBHBHBHEzBHBHadadCbCbisisCbCbisisCbitCbCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
-mImJadadadadadadadadadadadadadadadadadadadvGadadadadadaddsadadadadadadogadfiadadadadadadadadaeaeaeaeaeadadadadmNadadmNadadadadadmNadadmNadadadadadadvGadadadadadadadadadadadadadadadadadadhsadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTmTmTqqmTadadadadadpmadadadxVydwyyhyhhlyhyhhlyhyhwyngadaeaeaeaeaenPmVwemVmVmVmVmVwfmVmVyixZyjyexSykwfmVmVvVmVafwfmVmVmVyimVmVnGaeaeaeaeaeadiWiXiXiXiXiXiXiYiFwGxbwGwGxaxbxbFTylxbxbwGwGxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTrbmTmTmTmSadadadadymngngngadxVynwyyohmhnhmhmhmhmypwymVnGaeaeaeaeaenPxXmVwfyqyrysyrytyryrFWyryrxSxSxSyryryrFWyryryryryryumVwfmVnGaeaeaefuaeadjbyvyvyvyvyvyvjdadwGxbxbywxaxbxbyxxbyyxbywxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTqqmTrbmSfiadadFXvUyzvUxXnGxVydwyhmhmhmhmhmyAyBhnismVnGaeaeaeaeaenPmVmVvUyexSxSxSxSxSxSyCxSxSxSxSxSxSyDyDyDyExSxSxSxSxYmVmVvUyFaeaeaeaeaeadyGyvyHyIyIyJyvjdadwGxbxbxaxaxbylwGxbyyyKyLyMxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTmTrbmTrbmSadadyNwyisisisiswyyOyOwyyPyPyQwyyRyShrhmismVnGaeaeaeaeaexSyryrFWxSxSxSonononononononononxSxYadadafyexSxSxSxSxSyryryrxSaeaeaeaeaenJyGafafFYyIyIyTFZadwGwGxbxbxbxbxbywxbyyyyyyyywGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNqqrbrbrbmTmSadadwyxhxhxhxhyUyVxhxhwRxhxhxhyWhnhthuhmismVnGaeaeaeaeaexSyDyDyDxSxSxSonmTmTmTonyXyYyZonzazbafadadyexSxSxSFUxSyDyDyDxSaeaeagaeaeadyGafafyIyIyIyIjdadwGxbxbxbxbxbxbxbxbxbxbxbxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmTrbmTrbmTmSadadwyzcxhxhxhxhxhFSxhyUxhxhzdwyhmhmhmypwymVnGaeaeaeaeaenPzemVmVyexSxSonononononzfmTzgonxSxYzhafafyexSxSxSxSxYmVmVzinGaeaeaeaeaeadjbafyHyHyIzjyvzkadwGxbxbFTxTxbxbxbzlxbxbFTzmxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImNmSmSmSmSmSmSdeadwyxhxhznzozoxgxhznzozoxgxhwywywyzpwywyzqadaeaeagaeaenPmVmVmVyeyDxSonzrzsztonmToCzfonxSxSyryryrxSxSxSxSyDxYwfmVxXnGaeqdaeaeaepmjbyvzuyIyIzvyvjdadwGxbzwyxxbxbxbFTxbzlxbyxxbxbwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadadadadadadoWyOFSxhznzozoxgxhznzozoxgxhwyzxGahEzywyadadaeaeaeaeaenPmVmVmVzzmVyeonzrzAmTononzBonononzCononxSxSxSxSxYxXzDmVnxmVnGaeaernaeaeadjbyvyIyIyIzvafjdadwGwGwGwGwGwGxbxbxbwGwGwGwGwGwGadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJaddeadadadadadadyOxhzExhxhxhFSxhxhzFxhxhFSwyzxhEhEhEafadwYaeaeaeaerTnPmVwfmVzzvUGbonzroCoConzGzGzHzGzGzGzGonxSFUxSxSzImVzJmVmVmVnGaeaeaeaeaeadjbyvyIyHFYzvafzKadadaddeadadwGwGzLwGwGiFadadadaddeadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadwywyisisisiswywywyzcxhxhzMxhxhxhxhxhzdwywyzNzOhEafasvwaeaeaeaeaenPwemVzizzvVyeonmToCzPzBzGzGzGzGzGzHzGonxSxSxSxSzQvUzDmVmVmVnGqdaeaeaeaeadjbyvyIyHyJyJyvjdadngngngzRngadadadadiFadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadzSwyxDxhxhzExhxDxhxhFSxhxhxhzTxhxhzUxhxhxHwyzVhEafafafvwaeaeaeaeaezWxZmVmVzzmVyeonzXzYmTonzZAaAbAbAbAcAdonxSxSxSxSxYzizDmVwfmVnGaeaeaeaeaeadjbyvyvyvyvyvyvjdnPmVmVmVmVmVnGadiWiXiXiXiXiXiXiYadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadcewyxhxhznzozoxgAexhznzozoxgFSznzozoxgxhzdwywyGagNafafvwaerTaeaeaenPmVmVmVzzmVyeonononononAfAgAhAhAhAiAfonxSAjxSxSxYvUzDmVmVmVnGaeaeaeaeaeadjbyvAkAkAkAkyvjdnPmVnFmVmVmVnGadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJaddeyOxhzExhFSxhxhxhxhxhxhxhxhxhxhxhxhFSxHxhwyzxhEAlwyafadaeaeagaeaenPmVAmmVyeyrAnxSxSxSxSxSxSxSxSAoxSzaxSxSxSxSxSxSxSyrxYmVwfvVnGaeaeaeaeaeadjbApApApApApApjdnPmVmVmVmVmVvWdejbmQmQmQmQxAmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadAqwyxhArxhxhArxhxhxhxhxhxGxhxhArxhxhxhxhxhwyAshEhEhEadadaeaeaeaeaenPmVxXwfyexSxSxSxSyDAtxSAuAuAvAuFUAuAuxSyDyDxSxSAjxSxYmVmVmVnGaeaeaeaeaeadjUjVjVjVjVjVjVAwadoLoLoLoLoLadadAxmQmQmQmQmQmQAyadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadzSwywywyyOyOwywywyxhxhFSxNxhwywywyyOyOwywywyzxzxzxwypmadaeaeaeaeaexSyryrFWxSxSxSAnxYmVmVyeAuAuAzAuxSAuAuxYwemVyeAjxSxSxSyryryrxSaeaeaeaeaeaddeadadadadadogaddeadadpmpmadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadcewyxhxDxhxhxDxhwyxhznzoAAxhwyxhxhxhxhxhxhwywywywywyaddeaeaeaeaeaexSyDyDABAnxSxSxSACzimVyeAuAuxSAuxSAuAuADxXmVyexSxSxSAEyDGcyDxSaeaeaeaejBadngononononononononononngadadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJdsdsAFxhznzozoxgFSwyxhznzoAAxhwyxhznzozoxgxhwyAGAGAGwyadadaeaeaeaeaenPmVmVmVyeAHxSxSxSyumVyeAuAuxSAuAzAuAuxYmVyqxSxSxSAExYvVmVmVnGaeAIaeaeaenPyjonAJAKAKALoyAMAKANonAOnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadAFzcznzozoxgzdwyzcznzoAAzdwyzcznzozoGdzdwyAGAGAGwyrdadaeaeaeaeaenPwfmVmVAPyDyDAnxSyDAQyDyDARyDyDyDyDyDyDAQyDxSxSyDASATmVmVxXnGaeaeagaeaenPmVpxoyoyAUoyoyoyoyAVpxmVnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadAFxhznzozoxgxhAWxhznzoAAxhwyxhznzozoxgxhwyAGAGAGwyadfiaeaeaeaeaenPvUmVmVmVzimVGbxYxZmVwfmVmVAXAOmVmVmVvVmVwfGbAYwfmVmVmVmVmVnGaeaeaeAIaenPmVpxoyoyAZAKAKAKBaoypxmVnGrradadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJBbBbBcxhxhxhxhxhxhAWxhxhFSxhxhwyxhxhxhxhxhxhwyAGAGAGwyadadaeaeagaegPnPxZmVmVmVmVvUyeBdmVwfxXmVmVmVmVmVmVmVvVAOmVyexYmVmVmVmVmVBenGaeaeaeaeaenPmVpxBfoyAKAKAKAKBaBgpxmVnGadadadjbmQmQmQmQmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJpmadBcBcBhBhBhBhAFAFAFBhBhBhBcAFAFBhBhBhBhAFAFAFAFAFAFadadgOaeaeaeaenPmVziwfmVvUmVyexYmVmVmVmVmVmVvVAOwfmVmVBimVyexYmVvVmVvUwfmVnGaeaeaeaeaenPmVonAKBjBkoyoyBkoyBlonmVnGdeadadjbmQmQmQmQmQmQjdaddemJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadnPmVmVAmmVmVmVBmmVmVmVmVmVBmmVmVmVmVmVnGadstadaddsadadaeaeaeaeaeadEzoLoLoLoLoLxSxSoLoLoLoLoLBnoLoLoLoLBooLoLxSxSoLoLoLBpoLoLadaeaeaeaeaehsoLonpxpxonBqBqonpxpxonoLadadadadjbBrmQmQBrmQmQjdadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJBsadadoLBtoLoLBuoLdeoLoLoLoLoLngBvBvBwBvBvngdeadadBxdsadadaeaeaeAIaeaeadadadadadadxSFUadhsadadadadadrradadadadadxSFUadadadadadadaeaeaeaeaeaeadddadadadByadadafadaddeadadadadadjUjVBzjVjVjVjVjWadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJaddeadBsadBsadadBAadadBAadBsnPmVmVmVBBmVmVmVnGvGadaddshsadaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaetsaeagaeaeaeaeadadadadadBCgLafadadadadadadadadoaadadadadadadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadafBsadadadadBbBbBbadadadngBDBDBEBDBFBDBEBDBDngadvGdsadadaeaeBGagaeaeAIaeaeaeaeaeaeaeaeaeaeaeaeaejBaeaeaeaeaeaeaeaeaeaejBaeaefuaeaegMaeaeaeadadBHBHBHBHmQafBImQBHafBHBHBHadkmnkBJkmaddeadadadadadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadBKBKBLafBMBNBKBOBKBKBKnPmVBDBPBQBRBSBRBTBUBDmVnGaddsadadaeaeaeaeaeaeaeaeaeagaeaejBaejBaesjagaeaeaeaerTagaeaeaeaeaeaeagaefuaeaeaeaeaeaeaeaeadhsBHBVBWBWBHBIafafafoIBXBYBHdeBZafafCaadCbCbCbCbCbCbCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadBKBOBOCdBMBOBKmQCeCfCgChCiBECjCkBSBSBSCjCkBEmVGeaddsadadadaeaeaeaeBGaeaeaeaeaeaeaeaeaeaefuaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeadadadBHClBXBXCmmQGfafmQBXBXBWBHddCnafafCnadCbhlhmhmhnhoCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJBsBOBOCgBKCeBOComQCpCqadadmVBDCrCsCtCtBSCuCvBDmVnGaddsadrdadadaeaeAIaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeCwaeaeaeaeaeaeaeaeaeaeaddeadadBHCxGgBXBHmQCzmQBHBYCACBBHadkmmVafkmadCbhphmhqhrhmCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJafGhBMBKBKBKBMBOBLadafadCCmVBECjCkBSBSCtCjCkBEmVnGaddsdeadadadadadngngngadngngngadadadadaeaeaeaeaeaddeadadadadadadadadadadadadadadadadadadadrdadBHBHBHBHBHBHCDBHBHBHBHBHBHadCEafmVCFadCbhmhmhthuhmCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJafafBOCeBKCgBOCGafafadadnPmVBDCuCsCtBSBSCuCsBDmVnGaddsadadadadadnPmVmVmVBmmVmVmVnGaddeadaeaeaeaeaeadadadadadadadafafdeafadadadadadadadadadadadadadBHBHCHBICIBICJCKGiBHBHadCLCnnInjCnadhvhnhmhmhnhmCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJafBKCpmQCMBOCNBKafCOCPCOadoLBDCQCRCSCTCSCQCRBDBDBDBDCUadwywywyCVwywyisisisisiswywywyadadaeaeaeaeaeadadCWCXCXCXCXCXafafafCXCXCXCXCXCXCXCXCXCXCXCYadBHBHCZBIBHGjBHBIDbBHBHdeadCLadadaddeCbhwhxhmhmhyCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJafBKDcafCdBOBKBKDdadadadDeadBDDfDgDhDiDjDhDkBDDlDlDlCUadwyDmhHDnAGhHhHhHhHhHDoDpDqwyCLadaeaeagaeaeadadDrDsmVmVmVmVafafmVDtDsmVmVmVmVyjmVmVmVDsDrafGkmQBHBIBIBIGlBIBHBHBHDwadCbCbCbCbCbCbCbCbCbhzCbCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadasafafadBsadaddeadDxadadBsBDBSDyCRBSCQDzBSBDDlDlDlCUadwyDohHDAhHAGhHhHAGhHhHAGDBwyadaeaeaeaeaeaeaeadDrmVDDDDmVDDafDEDDDDmVDDDDmVDDDDmVDDDDmVDradmQBHBHBHDFBIDGBHBHBHBHadadCbhAhmhmhvhBCbhChDhEhFCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadocafadDHDIDIDIDJDIDIDKadBDBSBSBSDLBSDMBSBDDlDlDlCUadwywywywywywyDNDODODOwyxIwywyadaeaeaeaeaeaeaeadDrmVDDDDmVDPDDmVDDDDmVDDDDmVDDDDmVDDDDmVDradBHafBHBHBHCDBHBHBHBHBHiFadCbhGhnhmCbCbCbhEhHhIhECcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJDQBJkmBsadDRmVmVmVmVDSDTDUadBDBDBDDVBDBDBDBDBDBDBDBDCUadwyDWDXwODYwyhEAGDZhEwyxhEawyadaeaeaeaeaeaeaeadEbGmDDDDmVDDDDDtDDDDmVEcDDmVDDDDmVDDDDmVDrssBHBHEdEeBIGiafGnEeBHBHaddeCbhKhmhmhvhLCbhMhNhOhPCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJmVafBKEgEgDRmVmVmVmVDSmVEhadEiadadadadadaddeadadadaddsadwyzcEjxhxhxIAGhEhEhExIxhEkwyadaeaeaeaeaeaeaeadElmVDDDDmVDDDDmVEmDDtZDDDDmVDDDDmVDDDDmVDradBHBHEnBIBIEoBIgVCJBHBHadadCbCbhvCbCbCbCbhQEphQhRCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJmVafBKadadDRmVmVmVmVmVmVDUadBDBDBDBDBDBDBDEqBDBDBDBDCUadwyErwOEswRwyEtEuEvEwwywywywyadaeaeaeagaeaeaeadDrmVDDDDmVDDDDExDDDDmVDDDDmVDDDDnxDDDDmVDradBHBHBICJEyBInXasBIGoBHadadCbhSxkhThShUhVhSEAhShSCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJafmVEBadadDRmVmVmVmVDTmVDUEgBDECEDEEEFBDEGEEBDEHEHEHCUadwywywywywywywywywywywyhsadadadaeaeaeaeaeaeaeadDrmVDDDDmVDDDDmVDDDDExDDDDmVDDDDmVDDDDmVDradBHEIGiEJBHEKBHEJELEMBHogiFCbxkhXhSENhShShShShXhYCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJafafBKadadDRmVmVmVtZmVmVDUadBDEOEEEEEEEqEEEEEqEEEEEPCUadadadadadwxadadadadadadadadhsadaeaeaeaeaeaeaeadDrDsmVmVmVmVmVmVmVmVDsmVmVmVmVmVmVmVmVDsDradBHBHCIDbBHBHBHEQBIGoBradadCbhZiaiaibhZicidibhSieCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJmVmVkmdeadDRmVmVmVmVDSDtGpadBDEEEEERESBDETEUBDEHEHEHCUadaddeadadadadadaddeadadkmkmadadaeaeaeaeaeaeaeadEVCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXCXEWddBHBHBIBIBIBInUwdasafmQadadCbijiaikibiliaiaibEXimCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJniEYBKadadEZFaFaFaFaFaFaFbadBDBDBDBDBDBDBDBDBDBDBDBDCUadadkmkmkmkmkmkmadadadkmkmaddeadaeaeaeagaeaeaeaddeadadadadadadadadadaddeadadadadadadadadadadBHBHBHBHBHBHBHBHafBHBHadadCbCbisisCbCbisisCbitCbCcmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
+mImJadadadadadadadadadadadadadadadadadadadvGadadaddeadaddsadadadadadadogadfiadadadadadadadadaeaeaeaeaeadadadadmNadadmNadadadadadmNadadmNadadadadaddevGadadadadadadadadadafaddeadadadadadadhsadadaddeadmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJdsdtdtdtdtdtdsmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImJdsdtdtdtdtdtdsmJmImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImI
 mImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImImIabacacacacacacacacacacacacacadaeaeaeadafacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacab


### PR DESCRIPTION
- - -
Map:
 - Courtesy of Magnum, he's gone and done the tedious work of noding the northern part of standard.dmm. Cheers.
- - -
Balance:
 - Gives deployable sentries a full screen scan, rather than limiting them to viewcones. We'll see how this works.
 - 360 scan provided to UNSC base defense turrets, alongside being able to see targets in stealth.
- - -
Other:
 - Description for 'URF vs UNSC' corrected to reflect how the gamemode will be used.
- - -