### PR TITLE
Economy Dump Disabled & No-Laser-Pass-Through

### DIFF
--- a/burgerstation.dme
+++ b/burgerstation.dme
@@ -470,7 +470,6 @@
 #include "code\_core\datum\enchantment\_enchantment.dm"
 #include "code\_core\datum\enchantment\enchantment_types.dm"
 #include "code\_core\datum\event\_event.dm"
-#include "code\_core\datum\event\economy_dump.dm"
 #include "code\_core\datum\experience\_experience.dm"
 #include "code\_core\datum\experience\attributes.dm"
 #include "code\_core\datum\experience\skills.dm"

--- a/code/_core/obj/item/_item.dm
+++ b/code/_core/obj/item/_item.dm
@@ -172,7 +172,7 @@
 	return .
 
 /obj/item/get_base_value()
-	return value * item_count_current * price_multiplier
+	return value * item_count_current/* * price_multiplier*/
 
 /obj/item/proc/transfer_item_count_to(var/obj/item/target,var/amount_to_transfer = item_count_current)
 	if(!amount_to_transfer) return 0

--- a/code/_core/obj/projectile/laser.dm
+++ b/code/_core/obj/projectile/laser.dm
@@ -7,7 +7,8 @@
 
 	muzzleflash_effect = /obj/effect/temp/muzzleflash/laser
 
-	collision_bullet_flags = FLAG_COLLISION_BULLET_LIGHT
+//	collision_bullet_flags = FLAG_COLLISION_BULLET_LIGHT
+	collision_bullet_flags = FLAG_COLLISION_BULLET_SOLID//temp
 
 	plane = PLANE_EFFECT_LIGHTING
 


### PR DESCRIPTION
- - -
Balance:
 - Plasma weaponry no longer phases through windows.
- - -
Other:
 - economy_dump.dm has been unloaded. We still have the credit system, but it's hard enough as is without this screwing with player loadouts.
- - -